### PR TITLE
ci: add merge-schedule workflow to replace pr-scheduler

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -1,0 +1,40 @@
+# Scheduled merge of pull requests (free alternative to pr-scheduler)
+# Usage: append a line to the PR description, e.g.
+#   /schedule 2026-08-06T02:50:00+03:00   # merge at 02:50 GMT+3
+#   /schedule 2026-08-05T23:50:00.000Z    # UTC equivalent (02:50 GMT+3 = 23:50 UTC previous day)
+#   /schedule 2026-08-06                  # merge at the first cron run of that day
+#
+# Notes:
+# - The date must carry a timezone offset (+03:00 / Z); a bare time is parsed as UTC.
+# - Use ISO format YYYY-MM-DD. pr-scheduler's MM/DD/YYYY is misread (5/8 = May 8).
+# - time_zone only affects the "is it due yet" check and messages, not date parsing.
+# Reschedule: edit the PR description. Cancel: remove the /schedule line.
+
+name: Merge Schedule
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  schedule:
+    # Check every 10 minutes. GitHub may delay schedule events under load, but this
+    # action merges only when due, so a delayed run is caught by the next one
+    # (worst case: a few minutes late).
+    - cron: '*/10 * * * *'
+  workflow_dispatch: # manual check
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge-schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          merge_method: merge               # merge | squash | rebase
+          time_zone: Etc/GMT-3              # GMT+3 (e.g. Europe/Moscow; does not affect date parsing)
+          require_statuses_success: 'true'  # merge only when all checks pass; otherwise skip and retry next run
+          automerge_fail_label: automerge-fail # label applied on merge failure; remove it to retry


### PR DESCRIPTION
## Purpose
pr-scheduler is paid and unreliable (PR #38 scheduled for 2026-08-05 02:50 GMT+3 was merged at 00:54Z, ~1h late). This PR replaces it with the free, open-source [gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action).

## Usage (replaces the `@prscheduler 5/8/2026T02:50 GMT+3` comment)
Append a line to the PR description:
- `/schedule 2026-08-06T02:50:00+03:00` — merge at 02:50 GMT+3 (recommended)
- `/schedule 2026-08-06` — merge at the first cron run of that day

Use ISO dates (YYYY-MM-DD), not MM/DD/YYYY. The time must carry a timezone offset; a bare time is parsed as UTC.

## Behavior
- Cron runs every 10 minutes. GitHub may delay schedule events under load, but the action merges only when due, so the next run picks it up (worst case: minutes late, not an hour).
- Main branch is unprotected, so `GITHUB_TOKEN` can merge directly; no extra setup.
- On merge failure, a `automerge-fail` label is applied and a comment is posted; remove the label to retry.
- Repository is public: Actions are free with no minute limit.